### PR TITLE
Use randomExt.pick for candleSize in sample config

### DIFF
--- a/config/sample-config.js
+++ b/config/sample-config.js
@@ -43,7 +43,7 @@ const config = {
       up: randomExt.float(20,0).toFixed(2),
       down: randomExt.float(0,-20).toFixed(2),
     },
-    candleSize: config.candleValues[randomExt.integer(config.candleValues.length -1, 0)]
+    candleSize: randomExt.pick(config.candleValues)
   })
 };
 


### PR DESCRIPTION
Minor cleanup, since `randomExt` already exists, might as well use it to get the `candleSize`.