### PR TITLE
Enable nested properties for easier config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -170,9 +170,9 @@ class Ga {
   mutate(a, maxAmount) {
 
     let amt = randomExt.integer(maxAmount, 0);
-    // flatten, mutate, unflatten, run
+    // flatten, mutate, return unflattened object
     let flattened = flat.flatten(a);
-    let allProps = Object.keys(flattened);//Object.keys(a);
+    let allProps = Object.keys(flattened);
 
     let tmp = {};
 
@@ -246,17 +246,8 @@ class Ga {
       }
 
     } else {
-
       for (let j = 0; j < this.populationAmt; j++) {
-
-        // siehe https://github.com/gekkowarez/gekkoga/issues/28
         selectionProb[j] = populationProfits[j] / fitnessSum;
-        // if (populationProfits[j] > 0) {
-        //   selectionProb[j] = populationProfits[j] / fitnessSum;
-        // }
-        // else {
-        //   selectionProb[j] = 1 / (populationProfits[j] * fitnessSum);
-        // }
       }
 
     }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const randomExt = require('random-ext');
 const rp = require('request-promise');
 const { some } = require('bluebird');
 const fs = require('fs-extra');
+const flat = require('flat');
 
 class Ga {
 
@@ -169,7 +170,9 @@ class Ga {
   mutate(a, maxAmount) {
 
     let amt = randomExt.integer(maxAmount, 0);
-    let allProps = Object.keys(a);
+    // flatten, mutate, unflatten, run
+    let flattened = flat.flatten(a);
+    let allProps = Object.keys(flattened);//Object.keys(a);
 
     let tmp = {};
 
@@ -191,7 +194,7 @@ class Ga {
 
     }
 
-    return tmp;
+    return flat.unflatten(tmp);
   }
 
   // For the given population and fitness, returns new population and max score
@@ -246,8 +249,14 @@ class Ga {
 
       for (let j = 0; j < this.populationAmt; j++) {
 
+        // siehe https://github.com/gekkowarez/gekkoga/issues/28
         selectionProb[j] = populationProfits[j] / fitnessSum;
-
+        // if (populationProfits[j] > 0) {
+        //   selectionProb[j] = populationProfits[j] / fitnessSum;
+        // }
+        // else {
+        //   selectionProb[j] = 1 / (populationProfits[j] * fitnessSum);
+        // }
       }
 
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "commander": "^2.11.0",
+    "flat": "^4.0.0",
     "fs-extra": "^4.0.2",
     "nodemailer": "^4.4.1",
     "random-ext": "^2.6.1",


### PR DESCRIPTION
Allow users to use nested properties in GA-Config, just like in gekko.
Fixes things like https://github.com/gekkowarez/gekkoga/issues/30 or https://github.com/gekkowarez/gekkoga/issues/24 ...

Adds a new dependency on flat.js for flattening, deflattening the objects inside the mutate method.